### PR TITLE
Correct moved-to URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 This module has officially moved to the Magento2 github repo as part of Magento2 itself.
 
-Please check here: https://github.com/magento/magespecialist_TwoFactorAuth .
+Please check here: https://github.com/magento/security-package/tree/develop/TwoFactorAuth .
 
 You can always use `composer` to upgrade it, but you may need to change your version constraint to `3.*`.


### PR DESCRIPTION
I don't know if anyone is still maintaining this, but looks like this was since moved again.

It'd be great to update the link in the README